### PR TITLE
Customized Version of aws-security-reference-architecture-examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/guidance.md
+++ b/.github/ISSUE_TEMPLATE/guidance.md
@@ -13,7 +13,7 @@ a new issue! If your question was already asked, but the answer does not satisfy
 your curiosity, prefer re-opening the existing issue to ask for further
 clarification, instead of filing a new issue.
 
-[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/issues?utf8=✓&q=is%3Aissue+label%3Aguidance
+[1]: https://github.com/promethium-ai/aws-security-reference-architecture-examples/issues?utf8=✓&q=is%3Aissue+label%3Aguidance
 -->
 
 ### The Question

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@ Explain what changed and why.
 Please read the [Contribution guidelines][1], use the [General Contributing Guidance] checklist,
 and follow the pull-request checklist.
 
-[1]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
-[2]: https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
+[1]: https://github.com/promethium-ai/aws-security-reference-architecture-examples/blob/master/CONTRIBUTING.md
+[2]: https://github.com/promethium-ai/aws-security-reference-architecture-examples/blob/master/GENERAL-CONTRIBUTING-GUIDANCE.md
 -->
 
 Fixes # <!-- Please create a new issue if none exists yet -->

--- a/AWS-SRA-KEY-INFO.md
+++ b/AWS-SRA-KEY-INFO.md
@@ -7,7 +7,7 @@ Please find key information here on AWS SRA, survey's, previous session videos, 
 - AWS SRA Design Guidance: 
 	- https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html
 - AWS SRA Code Library: 
-	- https://github.com/aws-samples/aws-security-reference-architecture-examples
+	- https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 ## Surveys
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed<!-- omit in toc -->
 
-- Updated [Inspector](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to allow creation of AWSServiceRoleForAmazonInspector2Agentless SLR.
+- Updated [Inspector](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to allow creation of AWSServiceRoleForAmazonInspector2Agentless SLR.
 - Updated documentation for [EC2 Default EBS Encryption](aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption) solution.
 
 ## 2024-08-22
@@ -79,7 +79,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed<!-- omit in toc -->
 
 - Fixed [Terraform edition](aws_sra_examples/terraform) Workspace creation on suspended accounts.
-- Fixed [Firewall Manager](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/firewall_manager/firewall_manager_org) solution deployment issue (invalid operation error).
+- Fixed [Firewall Manager](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/firewall_manager/firewall_manager_org) solution deployment issue (invalid operation error).
 - Fixed [GuardDuty terraform](aws_sra_examples/terraform/solutions/guard_duty) module installation failure.
 
 ## 2024-06-24
@@ -116,11 +116,11 @@ All notable changes to this project will be documented in this file.
 
 ## 2023-10-23
 
-Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/firewall_manager/firewall_manager_org) solution to make AWS Control Tower optional.
+Updated [Firewall Manager](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/firewall_manager/firewall_manager_org) solution to make AWS Control Tower optional.
 
 ## 2023-10-10
 
-- Updated [Inspector](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to enable automatic lambda code scan.
+- Updated [Inspector](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to enable automatic lambda code scan.
 
 ## 2023-09-27
 
@@ -137,17 +137,17 @@ Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference
 
 ## 2023-08-07
 
-- Updated [Common Prerequisites](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) solution to make AWS Control Tower optional.
-- Updated [Security Hub](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/securityhub/securityhub_org) solution to make AWS Control Tower optional.
-- Updated [Inspector](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to make AWS Control Tower optional.
-- Updated [GuardDuty](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/guardduty/guardduty_org) solution to make AWS Control Tower optional.
-- Updated [Easy Setup](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/easy_setup) to support solution updates for making AWS Control Tower optional.
-- Updated [CloudTrail](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution to make AWS Control Tower optional.
-- Updated [IAM Access Analyzer](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/iam/iam_access_analyzer) solution to make AWS Control Tower optional.
+- Updated [Common Prerequisites](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) solution to make AWS Control Tower optional.
+- Updated [Security Hub](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/securityhub/securityhub_org) solution to make AWS Control Tower optional.
+- Updated [Inspector](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/inspector/inspector_org) solution to make AWS Control Tower optional.
+- Updated [GuardDuty](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/guardduty/guardduty_org) solution to make AWS Control Tower optional.
+- Updated [Easy Setup](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/easy_setup) to support solution updates for making AWS Control Tower optional.
+- Updated [CloudTrail](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution to make AWS Control Tower optional.
+- Updated [IAM Access Analyzer](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/iam/iam_access_analyzer) solution to make AWS Control Tower optional.
 
 ## 2023-07-07
 
-- Updated [CloudTrail](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution to enable delegated administrator.
+- Updated [CloudTrail](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution to enable delegated administrator.
 
 ## 2023-07-01
 
@@ -169,7 +169,7 @@ Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference
 ### Changed<!-- omit in toc -->
 
 - Added GuardDuty EKS, Malware, RDS, and Lambda protections [GuardDuty Organization](aws_sra_examples/solutions/guardduty/guardduty_org)
-- Added fix to support deploying to more than 50 accounts. https://github.com/aws-samples/aws-security-reference-architecture-examples/issues/139. UpdateMemberDetectors and CreateMembers parameters accountIds and accountDetails support a max number
+- Added fix to support deploying to more than 50 accounts. https://github.com/promethium-ai/aws-security-reference-architecture-examples/issues/139. UpdateMemberDetectors and CreateMembers parameters accountIds and accountDetails support a max number
   of 50 items
 
 ## 2023-05-12
@@ -345,7 +345,7 @@ Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference
 ### Changed<!-- omit in toc -->
 
 - Updated the [CFCT-DEPLOYMENT-INSTRUCTIONS.md](aws_sra_examples/docs/CFCT-DEPLOYMENT-INSTRUCTIONS.md) document to remove references to the common_cfct_setup solution.
-- [CloudTrail](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution
+- [CloudTrail](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/cloudtrail/cloudtrail_org) solution
   - Added main templates to simplify deployments via nested stacks.
   - Updated documentation, diagram, and templates to be consistent with the rest of the solutions.
   - Added integration with Secrets Manager to share CloudFormation output values with the management account.
@@ -424,7 +424,7 @@ Updated [Firewall Manager](https://github.com/aws-samples/aws-security-reference
 
 ### Changed<!-- omit in toc -->
 
-- Updates to the [stage_solution.sh](https://github.com/aws-samples/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/utils/packaging_scripts/stage_solution.sh) packaging script to support better error logging and include
+- Updates to the [stage_solution.sh](https://github.com/promethium-ai/aws-security-reference-architecture-examples/blob/main/aws_sra_examples/utils/packaging_scripts/stage_solution.sh) packaging script to support better error logging and include
   packaging of `common` solutions.
 - In [Common Prerequisites](aws_sra_examples/solutions/common/common_prerequisites) and [AWS Config Management Account](aws_sra_examples/solutions/config/config_management_account) solutions:
   - Updates to logging to include tracebacks for when exceptions are raised.

--- a/aws_sra_examples/docs/DOWNLOAD-AND-STAGE-SOLUTIONS.md
+++ b/aws_sra_examples/docs/DOWNLOAD-AND-STAGE-SOLUTIONS.md
@@ -10,7 +10,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
 2. [Download the SRA examples code from GitHub](#download-the-sra-examples-code-from-github).
 
    ```bash
-   git clone https://github.com/aws-samples/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
+   git clone https://github.com/promethium-ai/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
    cd $HOME/aws-sra-examples
    ```
 
@@ -58,7 +58,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-
 Clone the AWS SRA GitHub repository to your local machine `$HOME/aws-sra-examples` directory
 
 ```bash
-git clone https://github.com/aws-samples/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
+git clone https://github.com/promethium-ai/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
 cd $HOME/aws-sra-examples
 ```
 
@@ -75,7 +75,7 @@ cd $HOME/aws-sra-examples
 
     ```bash
     cd $HOME && rm -rf aws-sra-examples
-    git clone https://github.com/aws-samples/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
+    git clone https://github.com/promethium-ai/aws-security-reference-architecture-examples.git $HOME/aws-sra-examples
     cd $HOME/aws-sra-examples
     ```
 

--- a/aws_sra_examples/easy_setup/README.md
+++ b/aws_sra_examples/easy_setup/README.md
@@ -31,7 +31,7 @@ The first steps in the easy setup of the AWS SRA code library is focused on the 
 
 #### Deploying the Common Prerequisite Solution<!-- omit in toc -->
 
-The next steps within the easy setup of the AWS SRA code library focuses on deploying the common prerequisites solution which is provides the base resources shared and used by each of the core solutions that are provided through the AWS SRA code library (e.g. the GuardDuty AWS SRA solution, the Security Hub AWS SRA solution, etc.)  See ![Common Prerequisite](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information
+The next steps within the easy setup of the AWS SRA code library focuses on deploying the common prerequisites solution which is provides the base resources shared and used by each of the core solutions that are provided through the AWS SRA code library (e.g. the GuardDuty AWS SRA solution, the Security Hub AWS SRA solution, etc.)  See ![Common Prerequisite](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information
 
 #### Deploying AWS SRA Solutions<!-- omit in toc -->
 
@@ -57,7 +57,7 @@ Download the `sra-easy-setup.yaml` template by either navigating to it in the AW
 ##### Example Download Command<!-- omit in toc -->
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
+curl -LJO https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
 ```
 
 #### II. (Option A) Deployment using the AWS Console
@@ -179,7 +179,7 @@ Download the `sra-common-prerequisites-control-tower-execution-role.yaml` AWS SR
 ###### Example AWS SRA AWS Control Tower Execution Role Template Download Command<!-- omit in toc -->
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/main/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-control-tower-execution-role.yaml
+curl -LJO https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/main/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-control-tower-execution-role.yaml
 ```
 
 ##### Step 2 - Download the AWS SRA Easy Setup Template<!-- omit in toc -->
@@ -189,7 +189,7 @@ Download the `sra-easy-setup.yaml` template by either navigating to it in the AW
 ###### Example AWS SRA Easy Setup Template Download Command<!-- omit in toc -->
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
+curl -LJO https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
 ```
 
 ##### Step 3 - Download the AWS SRA Easy Setup Manifest<!-- omit in toc -->
@@ -207,7 +207,7 @@ You must leave the `pCreateAWSControlTowerExecutionRole` parameter set to `false
 ###### Example AWS SRA Easy Setup Manifest Download Command<!-- omit in toc -->
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
+curl -LJO https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/main/aws_sra_examples/easy_setup/customizations_for_aws_control_tower/manifest.yaml
 ```
 
 #### III. Deploy AWSControlTowerExecutionRole In Management Account
@@ -273,7 +273,7 @@ The `sra-clone-library`  AWS Lambda function perform the `start` operation for t
 
 #### 5 - AWS CloudFormation Deploys Common Prerequisite 1st Solution Stack<!-- omit in toc -->
 
-The AWS SRA code library common prerequisite `sra-common-prerequisites-staging-s3-bucket` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
+The AWS SRA code library common prerequisite `sra-common-prerequisites-staging-s3-bucket` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
 
 #### 6 - Amazon S3 Staging Bucket Created<!-- omit in toc -->
 
@@ -289,11 +289,11 @@ The `sra-codebuild` AWS CodeBuild project, after the AWS SRA code library has be
 
 #### 9 - AWS CloudFormation Deploys Common Prerequisite 2nd Solution Stack<!-- omit in toc -->
 
-The AWS SRA code library common prerequisite `sra-common-prerequisites-management-account-parameters` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
+The AWS SRA code library common prerequisite `sra-common-prerequisites-management-account-parameters` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
 
 #### 10 - AWS CloudFormation Deploys Common Prerequisite 3rd Solution Stack<!-- omit in toc -->
 
-The AWS SRA code library common prerequisite `sra-common-prerequisites-main-ssm` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
+The AWS SRA code library common prerequisite `sra-common-prerequisites-main-ssm` CloudFormation stack is launched.  See ![Common Prerequisite](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/solutions/common/common_prerequisites) for more information.
 
 #### 11 - AWS CloudFormation Deploys AWS SRA Solution Stacks<!-- omit in toc -->
 

--- a/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
+++ b/aws_sra_examples/easy_setup/templates/sra-easy-setup.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description:
   Creates the SRA CodeBuild Project that deploys the staging, common prerequisites, and other components of the SRA. - 'easy_setup' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse7p)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse7p)gh 
 Metadata:
   SRA:
     Version: 1.0
@@ -711,7 +711,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description: SRA Code Library Repository URL
     Type: String
   pRepoBranch:

--- a/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-module-main.yaml
+++ b/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-module-main.yaml
@@ -129,7 +129,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String
@@ -139,7 +139,7 @@ Parameters:
       SRA Code Library Repository branch name.  Can be used as branch or as tags (e.g. tags/v3.0.1)
     Type: String
   pTemplateURL:
-    Default: https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-solution.yaml
+    Default: https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-solution.yaml
     Description:
       SRA module solution template URL
     Type: String

--- a/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-solution.yaml
+++ b/aws_sra_examples/modules/cloudtrail-org-module/templates/sra-cloudtrail-org-solution.yaml
@@ -141,7 +141,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/modules/config-org-module/templates/sra-config-org-module-main.yaml
+++ b/aws_sra_examples/modules/config-org-module/templates/sra-config-org-module-main.yaml
@@ -166,12 +166,12 @@ Parameters:
       SRA CodeBuild project name
     Type: String
   pTemplateURL:
-    Default: https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/config-org-module/templates/sra-config-org-solution.yaml
+    Default: https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/config-org-module/templates/sra-config-org-solution.yaml
     Description:
       SRA module solution template URL
     Type: String
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/modules/config-org-module/templates/sra-config-org-solution.yaml
+++ b/aws_sra_examples/modules/config-org-module/templates/sra-config-org-solution.yaml
@@ -162,7 +162,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-module-main.yaml
+++ b/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-module-main.yaml
@@ -160,12 +160,12 @@ Parameters:
       SRA CodeBuild project name
     Type: String
   pTemplateURL:
-    Default: https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-solution.yaml
+    Default: https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-solution.yaml
     Description:
       SRA module solution template URL
     Type: String
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-solution.yaml
+++ b/aws_sra_examples/modules/guardduty-org-module/templates/sra-guardduty-org-solution.yaml
@@ -156,7 +156,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-module-main.yaml
+++ b/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-module-main.yaml
@@ -129,7 +129,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String
@@ -139,7 +139,7 @@ Parameters:
       SRA Code Library Repository branch name.  Can be used as branch or as tags (e.g. tags/v3.0.1)
     Type: String
   pTemplateURL:
-    Default: https://raw.githubusercontent.com/aws-samples/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-solution.yaml
+    Default: https://raw.githubusercontent.com/promethium-ai/aws-security-reference-architecture-examples/v3.0.4/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-solution.yaml
     Description:
       SRA module solution template URL
     Type: String

--- a/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-solution.yaml
+++ b/aws_sra_examples/modules/securityhub-org-module/templates/sra-securityhub-org-solution.yaml
@@ -142,7 +142,7 @@ Metadata:
 
 Parameters:
   pRepoURL:
-    Default: https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+    Default: https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
     Description:
       SRA Code Library Repository URL
     Type: String

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/lambda/src/app.py
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'account_alternate_contacts' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'account_alternate_contacts' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-configuration-role.yaml
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure Account Alternate Contacts in all accounts including the management account.  -
-  'account_alternate_contacts' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6j)
+  'account_alternate_contacts' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6j)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-global-events.yaml
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'account_alternate_contacts' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6j)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6j)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-main-ssm.yaml
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template adds alternate contacts for Billing, Operations, and Security communications to the accounts. Resolving SSM parameters. -
-  'account_alternate_contacts' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6j)
+  'account_alternate_contacts' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6j)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts.yaml
+++ b/aws_sra_examples/solutions/account/account_alternate_contacts/templates/sra-account-alternate-contacts.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template adds alternate contacts for Billing, Operations, and Security communications to the accounts. - 'account_alternate_contacts' solution
-  in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6j)
+  in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6j)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'ami_bakery_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'ami_bakery_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/codepipeline.py
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/codepipeline.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'ami_bakery_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'ami_bakery_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/iam.py
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/iam.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'ami_bakery_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'ami_bakery_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/s3.py
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/lambda/src/s3.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'ami_bakery_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'ami_bakery_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'ami_bakery_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-configuration.yaml
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure AMI Bakery within an AWS Organization - 'ami_bakery_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/ami_bakery/ami_bakery_org/templates/sra-ami-bakery-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure AMI Bakery within an AWS Organization - 'ami_bakery_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.1
 
-'cloudtrail_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'cloudtrail_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-bucket.yaml
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables and configures an AWS S3 bucket for the CloudTrail Organization trail in the Control Tower Log Archive account. -
-  'cloudtrail_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse0i)
+  'cloudtrail_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse0i)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-kms.yaml
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-kms.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables and configures an AWS KMS Key for the CloudTrail Organization trail in the Control Tower Audit account. - 'cloudtrail_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse0i)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse0i)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org-main-ssm.yaml
@@ -6,7 +6,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations CloudTrail in the Control Tower Management account with a customer managed KMS key created in the Audit
   account sending the encrypted logs to an S3 bucket created within the Log Archive account. - 'cloudtrail_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse0i)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse0i)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org.yaml
+++ b/aws_sra_examples/solutions/cloudtrail/cloudtrail_org/templates/sra-cloudtrail-org.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables and configures an AWS CloudTrail Organization trail in the Control Tower Management account. - 'cloudtrail_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse0i)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse0i)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/common/common_cfct_setup/templates/sra-common-cfct-setup-main.yaml
+++ b/aws_sra_examples/solutions/common/common_cfct_setup/templates/sra-common-cfct-setup-main.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template deploys Customizations for Control Tower (CFCT). - 'common_cfct_setup' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2a)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2a)
 Metadata:
   SRA:
     Version: 1.2
@@ -281,7 +281,7 @@ Resources:
                 - aws sts get-caller-identity
                 - echo Copying customizations-for-aws-control-tower.template template to SRA staging bucket cloudformation template...
                 - aws s3 cp customizations-for-aws-control-tower.template s3://sra-staging-$AWS_ACCOUNT_ID-$AWS_DEFAULT_REGION/sra-common-cfct-setup/templates/
-                - git clone https://github.com/aws-samples/aws-security-reference-architecture-examples.git
+                - git clone https://github.com/promethium-ai/aws-security-reference-architecture-examples.git
             post_build:
               commands:
                 - echo Build completed on `date`

--- a/aws_sra_examples/solutions/common/common_prerequisites/lambda/src/app.py
+++ b/aws_sra_examples/solutions/common/common_prerequisites/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'common_prerequisites' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'common_prerequisites' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/common/common_prerequisites/lambda/src/inline_lambda.py
+++ b/aws_sra_examples/solutions/common/common_prerequisites/lambda/src/inline_lambda.py
@@ -3,7 +3,7 @@
 
 Version: 1.0
 
-'common_prerequisites' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'common_prerequisites' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-control-tower-execution-role.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-control-tower-execution-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   AWS Control Tower Execution IAM Role Creation. - 'common_prerequisites' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 Metadata:
   SRA:
     Version: 1.1

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-main-ssm.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the pre-requisite resources for staging the SRA solutions. Resolving SSM parameters. - 'common_prerequisites' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 Metadata:
   SRA:
     Version: 1.3

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-management-account-parameters.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-management-account-parameters.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates AWS Control Tower Account SSM Parameters. - 'common_prerequisites' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-member-account-parameters.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-member-account-parameters.yaml
@@ -6,7 +6,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the pre-requisite SSM parameters for staging the SRA solutions in the member accounts by resolving the corresponding SSM
   parameters in the management account. - 'common_prerequisites' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 Metadata:
   SRA:
     Version: 1.1

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-secrets-kms.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-secrets-kms.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a KMS key for SRA secrets used to share CloudFormation outputs to the Management account. - 'common_prerequisites' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-staging-s3-bucket.yaml
+++ b/aws_sra_examples/solutions/common/common_prerequisites/templates/sra-common-prerequisites-staging-s3-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description:
   Creates the SRA staging S3 bucket to store solution Lambda source code, CloudFormation templates, and other deployment files. -
-  'common_prerequisites' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2h)
+  'common_prerequisites' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/common/common_register_delegated_administrator/lambda/src/app.py
+++ b/aws_sra_examples/solutions/common/common_register_delegated_administrator/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.1
 
-'common_register_delegated_administrator' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'common_register_delegated_administrator' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/common/common_register_delegated_administrator/templates/sra-common-register-delegated-administrator-ssm.yaml
+++ b/aws_sra_examples/solutions/common/common_register_delegated_administrator/templates/sra-common-register-delegated-administrator-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template deploys a custom resource in the Control Tower Management account to enable service access and delegates an administrator account. -
-  'common_register_delegated_administrator' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+  'common_register_delegated_administrator' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
   (sra-1ssgnse2n)
 
 Metadata:

--- a/aws_sra_examples/solutions/config/config_aggregator_org/templates/sra-config-aggregator-org-configuration.yaml
+++ b/aws_sra_examples/solutions/config/config_aggregator_org/templates/sra-config-aggregator-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations Config Aggregator in the Control Tower Audit account. - 'config_aggregator_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse3a)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse3a)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_aggregator_org/templates/sra-config-aggregator-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/config/config_aggregator_org/templates/sra-config-aggregator-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations Config Aggregator in the Control Tower Audit account. - 'config_aggregator_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse3a)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse3a)
 
 Metadata:
   SRA:
@@ -117,12 +117,12 @@ Resources:
         - cRegisterDelegatedAdmin
         - !Sub [
             "${pSRASolutionVersion} - This template enables an AWS Organizations Config Aggregator in the Control Tower Audit account. -
-            'config_aggregator_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated Admin
+            'config_aggregator_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples. Delegated Admin
             Solution - ${SolutionName}",
             SolutionName: !GetAtt rCommonRegisterDelegatedAdminStack.Outputs.oSRASolutionName,
           ]
         - !Sub ${pSRASolutionVersion} - This template enables an AWS Organizations Config Aggregator in the Control Tower Audit account. -
-          'config_aggregator_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
+          'config_aggregator_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples.
       ExecutionRoleName: AWSControlTowerExecution
       ManagedExecution:
         Active: true

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-delivery-bucket.yaml
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-delivery-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   Creates S3 buckets to store the conformance pack results. - 'config_conformance_pack_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse3o)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse3o)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-deployment.yaml
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-deployment.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   Template creates an AWS Config Organization Conformance Pack. - 'config_conformance_pack_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse3o)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse3o)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/config/config_conformance_pack_org/templates/sra-config-conformance-pack-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. - 'config_conformance_pack_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse3o)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse3o)
 
 Metadata:
   SRA:
@@ -234,12 +234,12 @@ Resources:
         - cRegisterDelegatedAdmin
         - !Sub [
             "${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. -
-            'config_conformance_pack_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated
+            'config_conformance_pack_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples. Delegated
             Admin Solution - ${SolutionName}",
             SolutionName: !GetAtt rCommonRegisterDelegatedAdminStack.Outputs.oSRASolutionName,
           ]
         - !Sub ${pSRASolutionVersion} - This template creates an AWS Organizations Config Conformance Pack in the Control Tower Audit account. -
-          'config_conformance_pack_org' solution in repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
+          'config_conformance_pack_org' solution in repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples.
       ExecutionRoleName: !Ref pStackExecutionRole
       ManagedExecution:
         Active: true

--- a/aws_sra_examples/solutions/config/config_management_account/lambda/src/app.py
+++ b/aws_sra_examples/solutions/config/config_management_account/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'config_management_account' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'config_management_account' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main-ssm.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-main-ssm.yaml
@@ -6,7 +6,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables AWS Config in the Control Tower Management account and adds the Management account to the AWS Config Aggregator in the Control
   Tower Audit account. Resolving SSM parameters. - 'config_management_account' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2s)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2s)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role for AWS Config Recorder in the Control Tower Management account. - 'config_management_account' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2s)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2s)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-update-aggregator.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account-update-aggregator.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template adds the Management account to the AWS Config Aggregator in the Control Tower Audit account. - 'config_management_account' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2s)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2s)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
+++ b/aws_sra_examples/solutions/config/config_management_account/templates/sra-config-management-account.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables AWS Config in the Control Tower Management account. - 'config_management_account' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse2s)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse2s)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/config/config_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'config_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'config_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/config/config_org/lambda/src/config.py
+++ b/aws_sra_examples/solutions/config/config_org/lambda/src/config.py
@@ -1,7 +1,7 @@
 """This script performs operations to enable, configure, and disable config.
 
 Version: 1.0
-'config-org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'config-org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-aggregator-org-configuration.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-aggregator-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations Config Aggregator in AWS Organization. - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role for configuring AWS Config Recorder in AWS Organization. - 'config_org' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-configuration.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables AWS Config in AWS Organization. - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-delivery-kms-key.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-delivery-kms-key.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the Config delivery KMS key - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-delivery-s3-bucket.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-delivery-s3-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the Config delivery S3 bucket - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-global-events.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables AWS Config in the AWS Organization and sets up AWS Config Aggregator in the Audit account. Resolving SSM parameters. - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 
 Metadata:
   SRA:
@@ -682,12 +682,12 @@ Resources:
         - cRegisterDelegatedAdmin
         - !Sub [
             "${pSRASolutionVersion} - This template enables an AWS Organizations Config Aggregator in AWS Organization. -
-            'config_aggregator_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated Admin
+            'config_aggregator_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples. Delegated Admin
             Solution - ${SolutionName}",
             SolutionName: !GetAtt rCommonRegisterDelegatedAdminStack.Outputs.oSRASolutionName,
           ]
         - !Sub ${pSRASolutionVersion} - This template enables an AWS Organizations Config Aggregator in AWS Organization. -
-          'config_aggregator_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
+          'config_aggregator_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples.
       ExecutionRoleName: !Ref pStackExecutionRole
       ManagedExecution:
         Active: true

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-sns-kms-key.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-org-sns-kms-key.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the KMS key for Config delivery SNS topic - 'config_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/config/config_org/templates/sra-config-sns.yaml
+++ b/aws_sra_examples/solutions/config/config_org/templates/sra-config-sns.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates Config delivery SNS topic in Audit account. - 'config_org' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8h)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/detective/detective_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/detective/detective_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'detective_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'detective_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/detective/detective_org/lambda/src/detective.py
+++ b/aws_sra_examples/solutions/detective/detective_org/lambda/src/detective.py
@@ -1,7 +1,7 @@
 """This script performs operations to enable, configure, and disable inspector.
 
 Version: 1.0
-'inspector2_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'inspector2_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'detective_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse80)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse80)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-configuration.yaml
+++ b/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure Detective within an AWS Organization - 'detective_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse80)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse80)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/detective/detective_org/templates/sra-detective-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure Detective within an AWS Organization - 'detective_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse80)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse80)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/lambda/src/app.py
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/lambda/src/app.py
@@ -3,7 +3,7 @@
 
 Version: 1.1
 
-'ec2_default_ebs_encryption' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'ec2_default_ebs_encryption' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-global-events.yaml
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'ec2_default_ebs_encryption' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse40)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse40)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-main-ssm.yaml
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This solution enables the EC2 default ebs encryption in each account and region. - 'ec2_default_ebs_encryption' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse40)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse40)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-role.yaml
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template deploys an IAM role for enabling the EC2 default ebs encryption in each account and region. - 'ec2_default_ebs_encryption' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse40)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse40)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption.yaml
+++ b/aws_sra_examples/solutions/ec2/ec2_default_ebs_encryption/templates/sra-ec2-default-ebs-encryption.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template deploys a Lambda function that enables the EC2 default ebs encryption in each account and region. - 'ec2_default_ebs_encryption'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse40)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse40)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.1
 
-'firewall_manager_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'firewall_manager_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-delegate-admin.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-delegate-admin.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables AWS Firewall Manager and delegates an administrator account. - 'firewall_manager_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4d)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4d)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-disassociate-iam-role.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-disassociate-iam-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to disassociate the administrator account - 'firewall_manager_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4d)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4d)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This solution enables Firewall Manager by associating a delegated administrator account, configuring a security group and WAF policy. -
-  'firewall_manager_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4d)
+  'firewall_manager_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4d)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-sg-policy.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-sg-policy.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a security group policy. - 'firewall_manager_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4d)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4d)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
+++ b/aws_sra_examples/solutions/firewall_manager/firewall_manager_org/templates/sra-firewall-manager-org-waf-policy.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template builds a Firewall Manager WAF v2 policy and deploys it. - 'firewall_manager_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4d)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4d)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/lambda/src/app.py
@@ -7,7 +7,7 @@ Configures GuardDuty in all provided regions:
 
 Version: 1.1
 
-'guardduty_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'guardduty_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/lambda/src/guardduty.py
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/lambda/src/guardduty.py
@@ -2,7 +2,7 @@
 
 Version: 1.1
 
-'guardduty_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'guardduty_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account - 'guardduty_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-configuration.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure GuardDuty - 'guardduty_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delete-detector-role.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delete-detector-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to delete the GuardDuty detector within each account and region. - 'guardduty_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delivery-kms-key.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delivery-kms-key.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the GuardDuty delivery KMS key - 'guardduty_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delivery-s3-bucket.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-delivery-s3-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates the GuardDuty delivery S3 bucket - 'guardduty_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/guardduty/guardduty_org/templates/sra-guardduty-org-main-ssm.yaml
@@ -6,7 +6,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations GuardDuty in the Control Tower Audit or another delegated admin account with a customer managed KMS key
   created in the Audit account sending the encrypted findings to an S3 bucket created within the Log Archive account. - 'guardduty_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse4k)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse4k)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-account.yaml
+++ b/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-account.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an account IAM Access Analyzer - 'iam_access_analyzer' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse52)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse52)
 
 Metadata:
   AWS::CloudFormation::Interface:

--- a/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-main-ssm.yaml
+++ b/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an organization IAM Access Analyzer - 'iam_access_analyzer' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse52)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse52)
 
 Metadata:
   SRA:
@@ -204,12 +204,12 @@ Resources:
         - cRegisterDelegatedAdmin
         - !Sub [
             "${pSRASolutionVersion} - This template creates an AWS Organizations IAM Access Analyzer in the Control Tower Audit account. -
-            'config_conformance_pack_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples. Delegated
+            'config_conformance_pack_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples. Delegated
             Admin Solution - ${SolutionName}",
             SolutionName: !GetAtt rCommonRegisterDelegatedAdminStack.Outputs.oSRASolutionName,
           ]
         - !Sub ${pSRASolutionVersion} - This template creates an AWS Organizations IAM Access Analyzer in the Control Tower Audit account. -
-          'config_conformance_pack_org' solution in repo, https://github.com/aws-samples/aws-security-reference-architecture-examples.
+          'config_conformance_pack_org' solution in repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples.
       ExecutionRoleName: !Ref pStackExecutionRole
       ManagedExecution:
         Active: true

--- a/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-org.yaml
+++ b/aws_sra_examples/solutions/iam/iam_access_analyzer/templates/sra-iam-access-analyzer-org.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an organization IAM Access Analyzer - 'iam_access_analyzer' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse52)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse52)
 
 Metadata:
   AWS::CloudFormation::Interface:

--- a/aws_sra_examples/solutions/iam/iam_password_policy/lambda/src/app.py
+++ b/aws_sra_examples/solutions/iam/iam_password_policy/lambda/src/app.py
@@ -13,7 +13,7 @@ ResourceProperties:
 
 Version: 1.1
 
-'iam_password_policy' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'iam_password_policy' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/iam/iam_password_policy/templates/sra-iam-password-policy-main-ssm.yaml
+++ b/aws_sra_examples/solutions/iam/iam_password_policy/templates/sra-iam-password-policy-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda and updates the account password policy. - 'iam_password_policy' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse59)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse59)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/iam/iam_password_policy/templates/sra-iam-password-policy.yaml
+++ b/aws_sra_examples/solutions/iam/iam_password_policy/templates/sra-iam-password-policy.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to update the account password policy - 'iam_password_policy' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse59)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse59)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'inspector_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'inspector_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
+++ b/aws_sra_examples/solutions/inspector/inspector_org/lambda/src/inspector.py
@@ -1,7 +1,7 @@
 """This script performs operations to enable, configure, and disable inspector.
 
 Version: 1.0
-'inspector2_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'inspector2_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'inspector_org' solution in the repo, 
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse76)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse76)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure Inspector within an AWS Organization - 'inspector_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse76)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse76)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-global-events.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'inspector_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse76)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse76)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/inspector/inspector_org/templates/sra-inspector-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure Inspector within an AWS Organization - 'inspector_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse76)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse76)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/macie/macie_org/lambda/src/app.py
@@ -7,7 +7,7 @@ Configures Macie in all provided regions:
 
 Version: 1.2
 
-'macie_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'macie_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/macie/macie_org/lambda/src/macie.py
+++ b/aws_sra_examples/solutions/macie/macie_org/lambda/src/macie.py
@@ -2,7 +2,7 @@
 
 Version: 1.2
 
-'macie_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'macie_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure Macie within the delegated administrator account - 'macie_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-configuration.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource to configure Macie within the delegated administrator account and each member account. - 'macie_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-delivery-kms-key.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-delivery-kms-key.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   Creates the Macie KMS Key This template creates a KMS key to encrypt Macie findings sent to S3. - 'macie_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-delivery-s3-bucket.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-delivery-s3-bucket.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to create the Macie finding delivery S3 bucket. - 'macie_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-disable-role.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-disable-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   Create an IAM role for disabling Macie Creates the Macie KMS Key This template creates an IAM role for disabling Macie . - 'macie_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/macie/macie_org/templates/sra-macie-org-main-ssm.yaml
@@ -6,7 +6,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template enables an AWS Organizations Macie in the Control Tower Audit or another delegated admin account with a customer managed KMS key
   created in the Audit account sending the encrypted findings to an S3 bucket created within the Log Archive account. - 'macie_org' solution in the
-  repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5m)
+  repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5m)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/README.md
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/README.md
@@ -182,7 +182,7 @@ Choose a Deployment Method:
 aws cloudformation deploy --template-file $PWD/aws-sra-examples/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-org-main-ssm.yaml --stack-name sra-patch-org-main-ssm --capabilities CAPABILITY_NAMED_IAM
 ```
 
-Refer to the [AWS SRA Easy Setup](https://github.com/aws-samples/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/easy_setup#customizations-for-control-tower-implementation-instructions) Guide to pick the best installation type for you.
+Refer to the [AWS SRA Easy Setup](https://github.com/promethium-ai/aws-security-reference-architecture-examples/tree/main/aws_sra_examples/easy_setup#customizations-for-control-tower-implementation-instructions) Guide to pick the best installation type for you.
 
 Choose to deploy the Patch Manager solution from within the chosen deployment type.
 

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 2.0
 'patchmgr_org' solution in the repo,
-https://github.com/aws-samples/aws-security-reference-architecture-examples
+https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/lambda/src/patchmgmt.py
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/lambda/src/patchmgmt.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'patch_mgmt' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'patch_mgmt' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-configuration-role.yaml
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to be distributed into all accounts to be assumed by the configuration Lambda Function in the Management Account -  - 'patch_mgmt' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-configuration.yaml
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to configure Patch Management within an AWS Organization - 'patch_mgmt' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-default-host-config-role.yaml
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-default-host-config-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a Default Host Configiguration IAM role to be distributed into all accounts for Configuring Default Host Management Configuration -  - 'patch_mgmt' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-org-global-events.yaml
+++ b/aws_sra_examples/solutions/patch_mgmt/patch_mgmt_org/templates/sra-patch_mgmt-org-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'patch_mgmt_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8r)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/lambda/src/app.py
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.1
 
-'s3_block_account_public_access' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'s3_block_account_public_access' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-global-events.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 's3_block_account_public_access' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5t)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5t)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-main-ssm.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates Lambda function and associated resources to enable the S3 account level block public access settings -
-  's3_block_account_public_access' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5t)
+  's3_block_account_public_access' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5t)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-role.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role for enabling S3 account public access block settings within each account - 's3_block_account_public_access'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5t)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5t)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
+++ b/aws_sra_examples/solutions/s3/s3_block_account_public_access/templates/sra-s3-block-account-public-access.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates Lambda function and associated resources to enable the S3 account level block public access settings -
-  's3_block_account_public_access' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse5t)
+  's3_block_account_public_access' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse5t)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'security_lake_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'security_lake_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/security_lake.py
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/security_lake.py
@@ -1,7 +1,7 @@
 """This script performs operations to enable, configure, and disable security lake.
 
 Version: 1.0
-'security_lake_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'security_lake_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/sra_ssm_params.py
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/lambda/src/sra_ssm_params.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'common_prerequisites' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'common_prerequisites' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-lakeformation-slr.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-lakeformation-slr.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'security_lake_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-meta-store-manager-role.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-meta-store-manager-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'security_lake_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'security_lake_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-configuration.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure Security Lake within an AWS Organization - 'security_lake_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-kms-key.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-kms-key.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT-0
 ########################################################################
 AWSTemplateFormatVersion: 2010-09-09
-Description: This template creates KMS key for Security Lake configurations - 'security_lake_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+Description: This template creates KMS key for Security Lake configurations - 'security_lake_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 Metadata:
   SRA:
     Version: 1

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-org-main-ssm.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT-0
 ########################################################################
 AWSTemplateFormatVersion: 2010-09-09
-Description: This template creates a custom resource Lambda to delegate administration and configure Security Lake within an AWS Organization - 'security_lake_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+Description: This template creates a custom resource Lambda to delegate administration and configure Security Lake within an AWS Organization - 'security_lake_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 Metadata:
   SRA:
     Version: 1

--- a/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-query-subscriber-role.yaml
+++ b/aws_sra_examples/solutions/security_lake/security_lake_org/templates/sra-security-lake-query-subscriber-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account -  - 'security_lake_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1u3sd7f8p)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/app.py
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.3
 
-'securityhub_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'securityhub_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/securityhub.py
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/lambda/src/securityhub.py
@@ -2,7 +2,7 @@
 
 Version: 1.2
 
-'securityhub_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'securityhub_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration-role.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure Security Hub in all accounts including the delegated administrator account.  - 'securityhub_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6b)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6b)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure SecurityHub within an AWS Organization - 'securityhub_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6b)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6b)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-global-events.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'securityhub_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6b)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6b)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main-ssm.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure SecurityHub within an AWS Organization - 'securityhub_org'
-  solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6b)
+  solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6b)
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-recorder-start-event.yaml
+++ b/aws_sra_examples/solutions/securityhub/securityhub_org/templates/sra-securityhub-org-recorder-start-event.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule in the home region of each member account to send config recorder start events to the home region of the management account. - 'securityhub_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples (sra-1ssgnse6b)
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples (sra-1ssgnse6b)
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/lambda/src/app.py
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/lambda/src/app.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-'shield_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'shield_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/lambda/src/shield.py
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/lambda/src/shield.py
@@ -1,7 +1,7 @@
 """This script performs operations to enable, configure, and disable shield.
 
 Version: 1.0
-'shield_org' solution in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+'shield_org' solution in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-configuration-role.yaml
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-configuration-role.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an IAM role to configure the delegated administrator account - 'shield_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples sra-1u3sd7f8u
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples sra-1u3sd7f8u
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-configuration.yaml
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-configuration.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure shield within an AWS Organization - 'shield_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples sra-1u3sd7f8u
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples sra-1u3sd7f8u
 
 Metadata:
   SRA:

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-global-events.yaml
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-global-events.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates an event rule to send organization events to the home region. - 'shield_org' solution in the repo,
-  https://github.com/aws-samples/aws-security-reference-architecture-examples sra-1u3sd7f8u
+  https://github.com/promethium-ai/aws-security-reference-architecture-examples sra-1u3sd7f8u
 Metadata:
   SRA:
     Version: 1.0

--- a/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-main-ssm.yaml
+++ b/aws_sra_examples/solutions/shield_advanced/shield_advanced/templates/sra-shield-advanced-main-ssm.yaml
@@ -5,7 +5,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description:
   This template creates a custom resource Lambda to delegate administration and configure shield within an AWS Organization - 'shield_org' solution in
-  the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples sra-1u3sd7f8u
+  the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples sra-1u3sd7f8u
 
 Metadata:
   SRA:

--- a/aws_sra_examples/terraform/solutions/terraform_stack.py
+++ b/aws_sra_examples/terraform/solutions/terraform_stack.py
@@ -2,7 +2,7 @@
 
 Version: 1.0
 
-AWS SRA terraform edition in the repo, https://github.com/aws-samples/aws-security-reference-architecture-examples
+AWS SRA terraform edition in the repo, https://github.com/promethium-ai/aws-security-reference-architecture-examples
 
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0


### PR DESCRIPTION
Initial commit. This repo is a fork of `aws-samples/aws-security-reference-architecture-examples'. This repo with be used to make customized configurations and modifications.
